### PR TITLE
Configure formatter rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/*
+.cache/*
+public/*
+package-lock.json

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+trailingComma: "es5"
+tabWidth: 2
+printWidth: 80
+endOfLine: "lf"
+htmlWhitespaceSensitivity: "css"
+arrowParens: "always"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "GATSBY_GRAPHQL_IDE=playground gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,json,md, module.scss, scss}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
You should be able to just run `npm run format` and have the code formatted.
I confirmed that my files aren't affected by the formatting so blame should only affect your files.